### PR TITLE
Workflows: Fix postioning of GraphiQL Editor

### DIFF
--- a/js/draw.js
+++ b/js/draw.js
@@ -198,40 +198,41 @@ var draw = {
 
             }
 
-            draw.elements.each(function() {
+            draw.elements.css({'cursor':'pointer'})
+
+            .each(function() {
+
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function() {draw.elClick(this.id);});
 
-            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
-            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
-        }
-    },
+            })
 
-    elClick : function(id) {
+            .click(function() {
 
-        //if ($(".theme").val() == "hand") draw.tChange();
-        draw.svg[draw.type] = $('svg').get(0);
+                var kinds = draw.kind[0];
+                draw.svg[draw.type] = $('svg').get(0);
+                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-        var jsonfile = '/assets/feed.json?t=' + $.now();
-        jsonfile = jsonfile.replace('assets', id);
-        $("#json").attr("href", jsonfile);
+                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-        $.getJSON(jsonfile).done(function(result){
+ 
+                var jsonfile = '/assets/feed.json?t=' + $.now();
+                jsonfile = jsonfile.replace('assets', this.id);
+                $("#json").attr("href", jsonfile);
 
-            var kinds = draw.kind[0];
-            var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+                $.getJSON(jsonfile).done(function(result){
 
-            var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
-            var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-            draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+                    var obj = result.items[4].items[itemIndex];
+                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
+                    if(itemIndex != index - 1) editor.setValue(draw.skema);
+                    else {$(".theme").val("simple"); draw.tChange();}
 
-            var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {$(".theme").val("simple"); draw.tChange();}
+                });
 
-        });
+            });
 
+        } 
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -199,13 +199,8 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
-
-            .each(function() {
-
-                this.parentNode.appendChild(this);
-
-            }).click(function() {draw.elClick(this.id);});
+            draw.elements.css({'cursor':'pointer'}).each(function() {
+                this.parentNode.appendChild(this);}).click(function() {draw.elClick(this.id);});
 
         } 
     },

--- a/js/draw.js
+++ b/js/draw.js
@@ -108,13 +108,13 @@ var draw = {
 
         } else {
 
+            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
+            editor.clearSelection(); editor.gotoLine(1, 1);
+
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
-
-            editor.clearSelection();
-            editor.gotoLine(1, 1);
 
             switch(draw.type) {
 
@@ -202,7 +202,11 @@ var draw = {
             draw.elements.css({'cursor':'pointer'}).each(function() {
                 this.parentNode.appendChild(this);}).click(function() {draw.elClick(this.id);});
 
+            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
+            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+
         } 
+
     },
 
     elClick : function(id) {

--- a/js/draw.js
+++ b/js/draw.js
@@ -205,35 +205,37 @@ var draw = {
 
                 this.parentNode.appendChild(this);
 
-            })
-
-            .click(function() {
-
-                var kinds = draw.kind[0];
-                draw.svg[draw.type] = $('svg').get(0);
-                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
-
-                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
-                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
-
- 
-                var jsonfile = '/assets/feed.json?t=' + $.now();
-                jsonfile = jsonfile.replace('assets', this.id);
-                $("#json").attr("href", jsonfile);
-
-                $.getJSON(jsonfile).done(function(result){
-
-                    var obj = result.items[4].items[itemIndex];
-                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
-                    if(itemIndex != index - 1) editor.setValue(draw.skema);
-                    else {$(".theme").val("simple"); draw.tChange();}
-
-                });
-
-            });
+            }).click(function() {draw.elClick(this.id);});
 
         } 
+    },
+
+    elClick : function(id) {
+
+        //if ($(".theme").val() == "hand") draw.tChange();
+
+        var kinds = draw.kind[0];
+        draw.svg[draw.type] = $('svg').get(0);
+        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+
+        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
+        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+
+
+        var jsonfile = '/assets/feed.json?t=' + $.now();
+        jsonfile = jsonfile.replace('assets', id);
+        $("#json").attr("href", jsonfile);
+
+        $.getJSON(jsonfile).done(function(result){
+
+            var obj = result.items[4].items[itemIndex];
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
+
+        });
+
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -212,13 +212,13 @@ var draw = {
 
         //if ($(".theme").val() == "hand") draw.tChange();
 
-        var kinds = this.kind[0];
-        this.svg[this.type] = $('svg').get(0);
-        var index = 0; for (key in kinds) {if(key == this.type) nIndex = index; index++;}
+        var kinds = draw.kind[0];
+        draw.svg[draw.type] = $('svg').get(0);
+        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
         var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
         var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-        this.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
 
         var jsonfile = '/assets/feed.json?t=' + $.now();
@@ -228,9 +228,9 @@ var draw = {
         $.getJSON(jsonfile).done(function(result){
 
             var obj = result.items[4].items[itemIndex];
-            this.input = obj.input; this.skema = this.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(this.skema);
-            else {$(".theme").val("simple"); this.tChange();}
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
 
         });
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -75,6 +75,7 @@ var draw = {
 
             } finally {
 
+                if (type == 'scenetree') {editor.destroy(); $("#editor").remove();} //editor.setValue("");
                 $('.loadingImg').hide();
                 draw.type = type;
                 draw.element();
@@ -97,7 +98,6 @@ var draw = {
 
         } else if(select != 'hand') {
 
-            if (type == 'scenetree') {editor.destroy(); $("#editor").remove();} //editor.setValue("");
             if (type == 'flowchart') {elements = $('svg rect.flowchart, svg path.flowchart');} 
             else if(type == 'railroad') {elements = $('svg path').first().add($('svg rect')).add($('svg path').last());}
             else if(type == 'nodelinks') {elements = $('svg g g g');}

--- a/js/draw.js
+++ b/js/draw.js
@@ -134,8 +134,8 @@ var draw = {
 
                     draw.elements = $('svg rect.start-element, svg rect.flowchart, svg path.flowchart, svg rect.end-element');
                     draw.elements.css({'fill-opacity':'0.1'})
-                               .mouseenter(function(){$(this).css('fill','teal')})
-                               .mouseout(function(){$(this).css('fill','')});
+                       .mouseenter(function(){$(this).css('fill','teal')})
+                       .mouseout(function(){$(this).css('fill','')});
 
                 break;
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -220,7 +220,7 @@ var draw = {
 
             var kinds = draw.kind[0];
             var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
-id
+
             var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
             var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
             draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});

--- a/js/draw.js
+++ b/js/draw.js
@@ -200,7 +200,7 @@ var draw = {
 
             draw.elements.each(function() {
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(e);});
+            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(this);});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}

--- a/js/draw.js
+++ b/js/draw.js
@@ -200,7 +200,7 @@ var draw = {
 
             draw.elements.each(function() {
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(this);});
+            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick();});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,6 +6,7 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
+editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -107,13 +108,13 @@ var draw = {
 
         } else {
 
-            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
-            editor.clearSelection(); editor.gotoLine(1, 1);
-
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
+
+            editor.clearSelection();
+            editor.gotoLine(1, 1);
 
             switch(draw.type) {
 
@@ -133,8 +134,8 @@ var draw = {
 
                     draw.elements = $('svg rect.start-element, svg rect.flowchart, svg path.flowchart, svg rect.end-element');
                     draw.elements.css({'fill-opacity':'0.1'})
-                       .mouseenter(function(){$(this).css('fill','teal')})
-                       .mouseout(function(){$(this).css('fill','')});
+                               .mouseenter(function(){$(this).css('fill','teal')})
+                               .mouseout(function(){$(this).css('fill','')});
 
                 break;
 
@@ -198,42 +199,41 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'}).each(function() {
-                this.parentNode.appendChild(this);}).click(function() {draw.elClick(this.id);});
+            draw.elements.css({'cursor':'pointer'})
 
-            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
-            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+            .each(function() {
+
+                this.parentNode.appendChild(this);
+
+            })
+
+            .click(function() {
+
+                var kinds = draw.kind[0];
+                draw.svg[draw.type] = $('svg').get(0);
+                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+
+                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+
+ 
+                var jsonfile = '/assets/feed.json?t=' + $.now();
+                jsonfile = jsonfile.replace('assets', this.id);
+                $("#json").attr("href", jsonfile);
+
+                $.getJSON(jsonfile).done(function(result){
+
+                    var obj = result.items[4].items[itemIndex];
+                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
+                    if(itemIndex != index - 1) editor.setValue(draw.skema);
+                    else {$(".theme").val("simple"); draw.tChange();}
+
+                });
+
+            });
 
         } 
-
-    },
-
-    elClick : function(id) {
-
-        //if ($(".theme").val() == "hand") draw.tChange();
-
-        var kinds = draw.kind[0];
-        draw.svg[draw.type] = $('svg').get(0);
-        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
-
-        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
-        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
-
-
-        var jsonfile = '/assets/feed.json?t=' + $.now();
-        jsonfile = jsonfile.replace('assets', id);
-        $("#json").attr("href", jsonfile);
-
-        $.getJSON(jsonfile).done(function(result){
-
-            var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {$(".theme").val("simple"); draw.tChange();}
-
-        });
-
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -29,9 +29,9 @@ var draw = {
         var g = $('.diagram').get(0);
 
         var select = $(".theme").val();
-        var type = (!draw.type)? 'sequence': draw.type;
-
         var font_size = (select == 'hand')? 14: 13;
+
+        var type = (!draw.type)? 'sequence': draw.type;
         var skema = (draw.skema)? draw.skema: editor.getValue();
         var input = (type != 'sequence')? draw.input: {theme: select, "font-size": font_size};
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -203,6 +203,9 @@ var draw = {
                 this.parentNode.appendChild(this);
             }).click(function() {draw.elClick(this.id);});
 
+            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
+            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+
         } 
     },
 
@@ -225,7 +228,7 @@ var draw = {
         $.getJSON(jsonfile).done(function(result){
 
             var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            draw.input = obj.input; draw.skema = draw.txEncode(obj.query);
             if(itemIndex != index - 1) editor.setValue(draw.skema);
             else {$(".theme").val("simple"); draw.tChange();}
 
@@ -246,7 +249,7 @@ var draw = {
 
     },
 
-    encode : function(data) {
+    txEncode : function(data) {
 
         return data.replace(/&apos;/g, "'")
                    .replace(/&quot;/g, '"')
@@ -266,6 +269,8 @@ var draw = {
         var regex = /[?&]([^=#]+)=([^&#]*)/g, url = window.location.href, params = {}, match;
         while(match = regex.exec(url)) {params[match[1]] = match[2];}
         this.params = params; console.log(this.params);
+
+        $(".theme").val("simple"); 
         this.diagram();
 
     },

--- a/js/draw.js
+++ b/js/draw.js
@@ -200,7 +200,7 @@ var draw = {
 
             draw.elements.each(function() {
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(this);});
+            }).css({'cursor':'pointer'}).click(function() {draw.elClick(this);});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}

--- a/js/draw.js
+++ b/js/draw.js
@@ -31,8 +31,9 @@ var draw = {
         var select = $(".theme").val();
         var type = (!draw.type)? 'sequence': draw.type;
 
+        var font_size = (select == 'hand')? 14: 13;
         var skema = (draw.skema)? draw.skema: editor.getValue();
-        var input = (type!='sequence')? draw.input: {theme: select, "font-size": 13};
+        var input = (type != 'sequence')? draw.input: {theme: select, "font-size": font_size};
 
         _.each(kinds, function(value, key) {
             if (key == type) {

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,7 +6,6 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
-editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -134,8 +133,8 @@ var draw = {
 
                     draw.elements = $('svg rect.start-element, svg rect.flowchart, svg path.flowchart, svg rect.end-element');
                     draw.elements.css({'fill-opacity':'0.1'})
-                               .mouseenter(function(){$(this).css('fill','teal')})
-                               .mouseout(function(){$(this).css('fill','')});
+                       .mouseenter(function(){$(this).css('fill','teal')})
+                       .mouseout(function(){$(this).css('fill','')});
 
                 break;
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -46,7 +46,7 @@ var draw = {
 
                     $('.diagram').html('')
                     editor.clearSelection(); editor.gotoLine(1, 1);
-                    if (type != 'sequence') $('.diagram').css({'overflow': 'hidden';});
+                    if (type != 'sequence') $('.diagram').css({'overflow': 'hidden'});
 
                 }
                 else {

--- a/js/draw.js
+++ b/js/draw.js
@@ -200,14 +200,14 @@ var draw = {
 
             draw.elements.each(function() {
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick();});
+            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(e);});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
         }
     },
 
-    elClick : function() {
+    elClick : function(e) {
 
         //if ($(".theme").val() == "hand") draw.tChange();
         draw.svg[draw.type] = $('svg').get(0);

--- a/js/draw.js
+++ b/js/draw.js
@@ -29,7 +29,7 @@ var draw = {
         var g = $('.diagram').get(0);
 
         var select = $(".theme").val();
-        var font_size = (select == 'hand')? 14: 13;
+        var font_size = (select == 'hand')? 12: 14;
 
         var type = (!draw.type)? 'sequence': draw.type;
         var skema = (draw.skema)? draw.skema: editor.getValue();

--- a/js/draw.js
+++ b/js/draw.js
@@ -54,12 +54,12 @@ var draw = {
                     editor.destroy();
                     $(".editor").removeClass();
 
-                    $('.diagram').html(" <canvas></canvas> ");
-                    $("#graphiql").height(375).css({'position':'absolute','top':0,'left':0});
-
                     //$('.editor').height($('.diagram').height() - 94);
                     //$('.editor-wrapper').height($('.editor').height() + 3);
                     //$('.chetabahana-skema').height($('.editor').height() + 200);
+
+                    $('.diagram').html(" <canvas></canvas> ");
+                    $("#graphiql").height(375).css({'position':'absolute','top':0,'left':0});
 
                 }
             }

--- a/js/draw.js
+++ b/js/draw.js
@@ -198,41 +198,40 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
-
-            .each(function() {
-
+            draw.elements.each(function() {
                 this.parentNode.appendChild(this);
+            }).css({'cursor':'pointer'}).click(function(e) {draw.elClick(this);});
 
-            })
+            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
+            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+        }
+    },
 
-            .click(function() {
+    elClick : function() {
 
-                var kinds = draw.kind[0];
-                draw.svg[draw.type] = $('svg').get(0);
-                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+        //if ($(".theme").val() == "hand") draw.tChange();
+        draw.svg[draw.type] = $('svg').get(0);
 
-                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
-                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+        var jsonfile = '/assets/feed.json?t=' + $.now();
+        jsonfile = jsonfile.replace('assets', this.id);
+        $("#json").attr("href", jsonfile);
 
- 
-                var jsonfile = '/assets/feed.json?t=' + $.now();
-                jsonfile = jsonfile.replace('assets', this.id);
-                $("#json").attr("href", jsonfile);
+        $.getJSON(jsonfile).done(function(result){
 
-                $.getJSON(jsonfile).done(function(result){
+            var kinds = draw.kind[0];
+            var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-                    var obj = result.items[4].items[itemIndex];
-                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
-                    if(itemIndex != index - 1) editor.setValue(draw.skema);
-                    else {$(".theme").val("simple"); draw.tChange();}
+            var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+            var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+            draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-                });
+            var obj = result.items[4].items[itemIndex];
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
 
-            });
+        });
 
-        } 
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,6 +6,7 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
+editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -107,13 +108,13 @@ var draw = {
 
         } else {
 
-            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
-            editor.clearSelection(); editor.gotoLine(1, 1);
-
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
+
+            editor.clearSelection();
+            editor.gotoLine(1, 1);
 
             switch(draw.type) {
 
@@ -198,35 +199,41 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'}).each(function() {
-                this.parentNode.appendChild(this);}).click(function() {draw.elClick(this.id);}
-            );
-        }
-    },
+            draw.elements.css({'cursor':'pointer'})
 
-    elClick : function(id) {
+            .each(function() {
 
-        var kinds = draw.kind[0];
-        draw.svg[draw.type] = $('svg').get(0);
-        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+                this.parentNode.appendChild(this);
 
-        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
-        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+            })
 
-        var jsonfile = '/assets/feed.json?t=' + $.now();
-        jsonfile = jsonfile.replace('assets', id);
-        $("#json").attr("href", jsonfile);
+            .click(function() {
 
-        $.getJSON(jsonfile).done(function(result){
+                var kinds = draw.kind[0];
+                draw.svg[draw.type] = $('svg').get(0);
+                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-            var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {$(".theme").val("simple"); draw.tChange();}
+                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-        });
+ 
+                var jsonfile = '/assets/feed.json?t=' + $.now();
+                jsonfile = jsonfile.replace('assets', this.id);
+                $("#json").attr("href", jsonfile);
 
+                $.getJSON(jsonfile).done(function(result){
+
+                    var obj = result.items[4].items[itemIndex];
+                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
+                    if(itemIndex != index - 1) editor.setValue(draw.skema);
+                    else {$(".theme").val("simple"); draw.tChange();}
+
+                });
+
+            });
+
+        } 
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,6 +6,7 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
+editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -107,13 +108,13 @@ var draw = {
 
         } else {
 
-            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
-            editor.clearSelection(); editor.gotoLine(1, 1);
-
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
+
+            editor.clearSelection();
+            editor.gotoLine(1, 1);
 
             switch(draw.type) {
 
@@ -198,9 +199,15 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'}).each(function() {
+            draw.elements.css({'cursor':'pointer'})
+
+            .each(function() {
+
                 this.parentNode.appendChild(this);
-            }).click(function() {
+
+            })
+
+            .click(function() {
 
                 var kinds = draw.kind[0];
                 draw.svg[draw.type] = $('svg').get(0);
@@ -209,6 +216,7 @@ var draw = {
                 var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
                 var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
                 draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+
  
                 var jsonfile = '/assets/feed.json?t=' + $.now();
                 jsonfile = jsonfile.replace('assets', this.id);
@@ -226,14 +234,6 @@ var draw = {
             });
 
         } 
-    },
-
-    pad : function(data, size) {
-
-        var s = String(data);
-        while (s.length < (size || 2)) {s = "0" + s;}
-        return s;
-
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -51,7 +51,6 @@ var draw = {
                 }
                 else {
 
-
                     //$('.editor').height($('.diagram').height() - 94);
                     //$('.editor-wrapper').height($('.editor').height() + 3);
                     //$('.chetabahana-skema').height($('.editor').height() + 200);

--- a/js/draw.js
+++ b/js/draw.js
@@ -198,41 +198,37 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
+            draw.elements.css({'cursor':'pointer'}).each(function() {
+                this.parentNode.appendChild(this);}).click(function() {draw.elClick(this.id);}
+            );
+        }
+    },
 
-            .each(function() {
 
-                this.parentNode.appendChild(this);
+    elClick : function(id) {
 
-            })
+        var kinds = draw.kind[0];
+        draw.svg[draw.type] = $('svg').get(0);
+        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-            .click(function() {
+        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
+        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-                var kinds = draw.kind[0];
-                draw.svg[draw.type] = $('svg').get(0);
-                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
-                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+        var jsonfile = '/assets/feed.json?t=' + $.now();
+        jsonfile = jsonfile.replace('assets', id);
+        $("#json").attr("href", jsonfile);
 
- 
-                var jsonfile = '/assets/feed.json?t=' + $.now();
-                jsonfile = jsonfile.replace('assets', this.id);
-                $("#json").attr("href", jsonfile);
+        $.getJSON(jsonfile).done(function(result){
 
-                $.getJSON(jsonfile).done(function(result){
+            var obj = result.items[4].items[itemIndex];
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
 
-                    var obj = result.items[4].items[itemIndex];
-                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
-                    if(itemIndex != index - 1) editor.setValue(draw.skema);
-                    else {$(".theme").val("simple"); draw.tChange();}
+        });
 
-                });
-
-            });
-
-        } 
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -57,7 +57,7 @@ var draw = {
 
                     $('.diagram').html(' <canvas></canvas> ');
                     var div = document.createElement('div'); div.setAttribute('id', 'graphiql');
-                    $('#graphiql').height(375).css({'position':'absolute','top':0,'left':0}).append('.editor-wrapper');
+                    $('#graphiql').height(375).css({'position':'absolute','top':0,'left':0}).append('.contact_left');
 
                 }
             }

--- a/js/draw.js
+++ b/js/draw.js
@@ -198,15 +198,9 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
-
-            .each(function() {
-
+            draw.elements.css({'cursor':'pointer'}).each(function() {
                 this.parentNode.appendChild(this);
-
-            })
-
-            .click(function() {
+            }).click(function() {
 
                 var kinds = draw.kind[0];
                 draw.svg[draw.type] = $('svg').get(0);
@@ -215,7 +209,6 @@ var draw = {
                 var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
                 var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
                 draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
-
  
                 var jsonfile = '/assets/feed.json?t=' + $.now();
                 jsonfile = jsonfile.replace('assets', this.id);
@@ -233,6 +226,14 @@ var draw = {
             });
 
         } 
+    },
+
+    pad : function(data, size) {
+
+        var s = String(data);
+        while (s.length < (size || 2)) {s = "0" + s;}
+        return s;
+
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -199,41 +199,43 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
-
-            .each(function() {
-
+            draw.elements.css({'cursor':'pointer'}).each(function() {
                 this.parentNode.appendChild(this);
+            }).click(function().click(function() {draw.elClick(this.id);});
 
-            })
+            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
+            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
 
-            .click(function() {
+        }
 
-                var kinds = draw.kind[0];
-                draw.svg[draw.type] = $('svg').get(0);
-                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+    },
 
-                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
-                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+    elClick : function(id) {
 
- 
-                var jsonfile = '/assets/feed.json?t=' + $.now();
-                jsonfile = jsonfile.replace('assets', this.id);
-                $("#json").attr("href", jsonfile);
+        //if ($(".theme").val() == "hand") draw.tChange();
 
-                $.getJSON(jsonfile).done(function(result){
+        var kinds = draw.kind[0];
+        draw.svg[draw.type] = $('svg').get(0);
+        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-                    var obj = result.items[4].items[itemIndex];
-                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
-                    if(itemIndex != index - 1) editor.setValue(draw.skema);
-                    else {$(".theme").val("simple"); draw.tChange();}
+        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
+        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-                });
+        var jsonfile = '/assets/feed.json?t=' + $.now();
+        jsonfile = jsonfile.replace('assets', id);
+        $("#json").attr("href", jsonfile);
 
-            });
+        $.getJSON(jsonfile).done(function(result){
 
-        } 
+            var obj = result.items[4].items[itemIndex];
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
+            else {draw.tChange();}
+
+        });
+
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -44,8 +44,9 @@ var draw = {
 
                 if (type != 'scenetree') {
 
-                    $('.diagram').html('');
+                    $('.diagram').html('')
                     editor.clearSelection(); editor.gotoLine(1, 1);
+                    if (type != 'sequence') $('.diagram').css({'overflow': 'hidden';});
 
                 }
                 else {
@@ -54,7 +55,7 @@ var draw = {
                     $(".editor").removeClass().html('');
 
                     $('.diagram').html(" <canvas></canvas> ");
-                    $("#graphiql").height(375).css({position:'absolute',top:0,left:0});
+                    $("#graphiql").height(375).css({'position':'absolute','top':0,'left':0});
 
                     //$('.editor').height($('.diagram').height() - 94);
                     //$('.editor-wrapper').height($('.editor').height() + 3);

--- a/js/draw.js
+++ b/js/draw.js
@@ -113,7 +113,7 @@ var draw = {
             //$('.editor').height($('.diagram').height() - 94);
 
             editor.clearSelection(); editor.gotoLine(1, 1);
-            editor.getSession().on('change', _.debounce(function() draw.diagram();}, 1000));
+            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
 
             switch(type) {
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -204,7 +204,6 @@ var draw = {
         }
     },
 
-
     elClick : function(id) {
 
         var kinds = draw.kind[0];
@@ -214,7 +213,6 @@ var draw = {
         var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
         var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
         draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
-
 
         var jsonfile = '/assets/feed.json?t=' + $.now();
         jsonfile = jsonfile.replace('assets', id);

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,7 +6,6 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
-editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -108,13 +107,13 @@ var draw = {
 
         } else {
 
+            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
+            editor.clearSelection(); editor.gotoLine(1, 1);
+
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
-
-            editor.clearSelection();
-            editor.gotoLine(1, 1);
 
             switch(draw.type) {
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -200,28 +200,28 @@ var draw = {
 
             draw.elements.each(function() {
                 this.parentNode.appendChild(this);
-            }).css({'cursor':'pointer'}).click(function() {draw.elClick(this);});
+            }).css({'cursor':'pointer'}).click(function() {draw.elClick(this.id);});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
         }
     },
 
-    elClick : function(e) {
+    elClick : function(id) {
 
         //if ($(".theme").val() == "hand") draw.tChange();
         draw.svg[draw.type] = $('svg').get(0);
 
         var jsonfile = '/assets/feed.json?t=' + $.now();
-        jsonfile = jsonfile.replace('assets', this.id);
+        jsonfile = jsonfile.replace('assets', id);
         $("#json").attr("href", jsonfile);
 
         $.getJSON(jsonfile).done(function(result){
 
             var kinds = draw.kind[0];
             var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
-
-            var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+id
+            var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
             var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
             draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -52,7 +52,7 @@ var draw = {
                 else {
 
                     editor.destroy();
-                    $(".editor").removeClass().html('');
+                    $(".editor").removeClass();
 
                     $('.diagram').html(" <canvas></canvas> ");
                     $("#graphiql").height(375).css({'position':'absolute','top':0,'left':0});

--- a/js/draw.js
+++ b/js/draw.js
@@ -51,8 +51,6 @@ var draw = {
                 }
                 else {
 
-                    editor.destroy();
-                    $(".editor").removeClass();
 
                     //$('.editor').height($('.diagram').height() - 94);
                     //$('.editor-wrapper').height($('.editor').height() + 3);
@@ -103,6 +101,8 @@ var draw = {
             else if(type == 'railroad') {elements = $('svg path').first().add($('svg rect')).add($('svg path').last());}
             else if(type == 'nodelinks') {elements = $('svg g g g');}
             else {elements = $('svg g.title, svg g.actor, svg g.signal');}
+
+            if(type == 'scenetree') {editor.destroy(); $(".editor").removeClass();}
             elements.each(function(index) {draw.node(index, this);}).click(function() {draw.click(this);});
 
         } 

--- a/js/draw.js
+++ b/js/draw.js
@@ -73,8 +73,9 @@ var draw = {
             } finally {
 
                 if (type == 'scenetree') {
-                    editor.destroy(); $("#editor").remove(); //editor.setValue("");
-                    $('#graphiql').show();
+                     $('#graphiql').show();
+                     editor.destroy(); //editor.setValue("");
+                     $("#editor").remove();
                 }
 
                 $('.loadingImg').hide();

--- a/js/draw.js
+++ b/js/draw.js
@@ -231,7 +231,6 @@ var draw = {
             var obj = result.items[4].items[itemIndex];
             draw.input = obj.input; draw.skema = draw.encode(obj.query);
             if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {$(".theme").val("simple"); draw.tChange();}
             else {draw.tChange();}
 
         });
@@ -271,6 +270,8 @@ var draw = {
         var regex = /[?&]([^=#]+)=([^&#]*)/g, url = window.location.href, params = {}, match;
         while(match = regex.exec(url)) {params[match[1]] = match[2];}
         this.params = params; console.log(this.params);
+
+        $(".theme").val("simple"); 
         this.diagram();
 
     },

--- a/js/draw.js
+++ b/js/draw.js
@@ -54,9 +54,8 @@ var draw = {
                     //$('.editor').height($('.diagram').height() - 94);
                     //$('.editor-wrapper').height($('.editor').height() + 3);
                     //$('.chetabahana-skema').height($('.editor').height() + 200);
-
                     $('.diagram').html(' <canvas></canvas> ');
-                    //$('<div/>', {id: 'graphiql'}).appendTo('.contact_left');
+
                 }
             }
         });
@@ -73,7 +72,11 @@ var draw = {
 
             } finally {
 
-                if (type == 'scenetree') {editor.destroy(); $("#editor").remove();} //editor.setValue("");
+                if (type == 'scenetree') {
+                    editor.destroy(); $("#editor").remove(); //editor.setValue("");
+                    $('#graphiql').show();
+                }
+
                 $('.loadingImg').hide();
                 draw.type = type;
                 draw.element();

--- a/js/draw.js
+++ b/js/draw.js
@@ -2,7 +2,7 @@ $(window).load(function() {draw.diagram();});
 $('.theme').change(function() {draw.change();});
 $('.download').click(function(ev) {draw.xmlData();});
 
-var editor = ace.edit("graphiql");
+var editor = ace.edit("editor");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
@@ -56,8 +56,9 @@ var draw = {
                     //$('.editor-wrapper').height($('.editor').height() + 3);
                     //$('.chetabahana-skema').height($('.editor').height() + 200);
 
-                    $('.diagram').html(" <canvas></canvas> ");
-                    $("#graphiql").height(375).css({'position':'absolute','top':0,'left':0});
+                    $('.diagram').html(' <canvas></canvas> ');
+                    var div = document.createElement('div'); div.setAttribute('id', 'graphiql');
+                    $('#graphiql').height(375).css({'position':'absolute','top':0,'left':0}).append('.editor-wrapper');
 
                 }
             }
@@ -75,6 +76,11 @@ var draw = {
 
             } finally {
 
+
+                if(type == 'scenetree') {
+                    editor.destroy(); $(".editor").remove(); //editor.setValue("");
+                }
+                
                 $('.loadingImg').hide();
                 draw.type = type;
                 draw.element();
@@ -101,8 +107,6 @@ var draw = {
             else if(type == 'railroad') {elements = $('svg path').first().add($('svg rect')).add($('svg path').last());}
             else if(type == 'nodelinks') {elements = $('svg g g g');}
             else {elements = $('svg g.title, svg g.actor, svg g.signal');}
-
-            if(type == 'scenetree') {editor.destroy(); $(".editor").removeClass();}
             elements.each(function(index) {draw.node(index, this);}).click(function() {draw.click(this);});
 
         } 

--- a/js/draw.js
+++ b/js/draw.js
@@ -209,7 +209,7 @@ var draw = {
 
     elClick : function(el) {
 
-        if ($(".theme").val() == "hand") draw.tChange();
+        //if ($(".theme").val() == "hand") draw.tChange();
 
         var jsonfile = '/assets/feed.json?t=' + $.now();
         jsonfile = jsonfile.replace('assets', el.id);

--- a/js/draw.js
+++ b/js/draw.js
@@ -56,9 +56,7 @@ var draw = {
                     //$('.chetabahana-skema').height($('.editor').height() + 200);
 
                     $('.diagram').html(' <canvas></canvas> ');
-                    var div = document.createElement('div'); div.setAttribute('id', 'graphiql');
-                    $('#graphiql').height(375).css({'position':'absolute','top':0,'left':0}).append('.contact_left');
-
+                    //$('<div/>', {id: 'graphiql'}).appendTo('.contact_left');
                 }
             }
         });

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,6 +6,7 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
+editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -107,15 +108,14 @@ var draw = {
 
         } else {
 
-            editor.clearSelection(); editor.gotoLine(1, 1);
-            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
-
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
 
- 
+            editor.clearSelection();
+            editor.gotoLine(1, 1);
+
             switch(draw.type) {
 
                 case 'flowchart':
@@ -134,8 +134,8 @@ var draw = {
 
                     draw.elements = $('svg rect.start-element, svg rect.flowchart, svg path.flowchart, svg rect.end-element');
                     draw.elements.css({'fill-opacity':'0.1'})
-                       .mouseenter(function(){$(this).css('fill','teal')})
-                       .mouseout(function(){$(this).css('fill','')});
+                               .mouseenter(function(){$(this).css('fill','teal')})
+                               .mouseout(function(){$(this).css('fill','')});
 
                 break;
 
@@ -199,42 +199,41 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'}).each(function() {
+            draw.elements.css({'cursor':'pointer'})
+
+            .each(function() {
+
                 this.parentNode.appendChild(this);
-            }).click(function() {draw.elClick(this.id);});
 
-            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
-            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+            })
 
-        }
+            .click(function() {
 
-    },
+                var kinds = draw.kind[0];
+                draw.svg[draw.type] = $('svg').get(0);
+                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
 
-    elClick : function(id) {
+                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
+                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
-        //if ($(".theme").val() == "hand") draw.tChange();
+ 
+                var jsonfile = '/assets/feed.json?t=' + $.now();
+                jsonfile = jsonfile.replace('assets', this.id);
+                $("#json").attr("href", jsonfile);
 
-        var kinds = draw.kind[0];
-        draw.svg[draw.type] = $('svg').get(0);
-        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+                $.getJSON(jsonfile).done(function(result){
 
-        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
-        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+                    var obj = result.items[4].items[itemIndex];
+                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
+                    if(itemIndex != index - 1) editor.setValue(draw.skema);
+                    else {$(".theme").val("simple"); draw.tChange();}
 
-        var jsonfile = '/assets/feed.json?t=' + $.now();
-        jsonfile = jsonfile.replace('assets', id);
-        $("#json").attr("href", jsonfile);
+                });
 
-        $.getJSON(jsonfile).done(function(result){
+            });
 
-            var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {draw.tChange();}
-
-        });
-
+        } 
     },
 
     xmlData : function() {
@@ -270,8 +269,6 @@ var draw = {
         var regex = /[?&]([^=#]+)=([^&#]*)/g, url = window.location.href, params = {}, match;
         while(match = regex.exec(url)) {params[match[1]] = match[2];}
         this.params = params; console.log(this.params);
-
-        $(".theme").val("simple"); 
         this.diagram();
 
     },

--- a/js/draw.js
+++ b/js/draw.js
@@ -75,11 +75,6 @@ var draw = {
 
             } finally {
 
-
-                if(type == 'scenetree') {
-                    editor.destroy(); $(".editor").remove(); //editor.setValue("");
-                }
-                
                 $('.loadingImg').hide();
                 draw.type = type;
                 draw.element();
@@ -102,6 +97,7 @@ var draw = {
 
         } else if(select != 'hand') {
 
+            if (type == 'scenetree') {editor.destroy(); $("#editor").remove();} //editor.setValue("");
             if (type == 'flowchart') {elements = $('svg rect.flowchart, svg path.flowchart');} 
             else if(type == 'railroad') {elements = $('svg path').first().add($('svg rect')).add($('svg path').last());}
             else if(type == 'nodelinks') {elements = $('svg g g g');}

--- a/js/draw.js
+++ b/js/draw.js
@@ -134,8 +134,8 @@ var draw = {
 
                     draw.elements = $('svg rect.start-element, svg rect.flowchart, svg path.flowchart, svg rect.end-element');
                     draw.elements.css({'fill-opacity':'0.1'})
-                               .mouseenter(function(){$(this).css('fill','teal')})
-                               .mouseout(function(){$(this).css('fill','')});
+                       .mouseenter(function(){$(this).css('fill','teal')})
+                       .mouseout(function(){$(this).css('fill','')});
 
                 break;
 
@@ -199,41 +199,38 @@ var draw = {
 
             }
 
-            draw.elements.css({'cursor':'pointer'})
-
-            .each(function() {
-
+            draw.elements.css({'cursor':'pointer'}).each(function() {
                 this.parentNode.appendChild(this);
-
-            })
-
-            .click(function() {
-
-                var kinds = draw.kind[0];
-                draw.svg[draw.type] = $('svg').get(0);
-                var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
-
-                var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(this.id);
-                var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-                draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
-
- 
-                var jsonfile = '/assets/feed.json?t=' + $.now();
-                jsonfile = jsonfile.replace('assets', this.id);
-                $("#json").attr("href", jsonfile);
-
-                $.getJSON(jsonfile).done(function(result){
-
-                    var obj = result.items[4].items[itemIndex];
-                    draw.input = obj.input; draw.skema = draw.encode(obj.query);
-                    if(itemIndex != index - 1) editor.setValue(draw.skema);
-                    else {$(".theme").val("simple"); draw.tChange();}
-
-                });
-
-            });
+            }).click(function() {draw.elClick(this.id);});
 
         } 
+    },
+
+    elClick : function(id) {
+
+        //if ($(".theme").val() == "hand") draw.tChange();
+        draw.svg[draw.type] = $('svg').get(0);
+
+        var kinds = draw.kind[0];
+        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+
+        var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
+        var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
+        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+
+        var jsonfile = '/assets/feed.json?t=' + $.now();
+        jsonfile = jsonfile.replace('assets', id);
+        $("#json").attr("href", jsonfile);
+
+        $.getJSON(jsonfile).done(function(result){
+
+            var obj = result.items[4].items[itemIndex];
+            draw.input = obj.input; draw.skema = draw.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(draw.skema);
+            else {$(".theme").val("simple"); draw.tChange();}
+
+        });
+
     },
 
     xmlData : function() {

--- a/js/draw.js
+++ b/js/draw.js
@@ -29,7 +29,7 @@ var draw = {
         var g = $('.diagram').get(0);
 
         var select = $(".theme").val();
-        var font_size = (select == 'hand')? 12: 14;
+        var font_size = (select == 'hand')? 13: 14;
 
         var type = (!draw.type)? 'sequence': draw.type;
         var skema = (draw.skema)? draw.skema: editor.getValue();

--- a/js/draw.js
+++ b/js/draw.js
@@ -29,11 +29,10 @@ var draw = {
         var g = $('.diagram').get(0);
 
         var select = $(".theme").val();
-        var font_size = (select == 'hand')? 13: 14;
-
         var type = (!draw.type)? 'sequence': draw.type;
+
         var skema = (draw.skema)? draw.skema: editor.getValue();
-        var input = (type!='sequence')? draw.input: {theme: select, "font-size": font_size};
+        var input = (type!='sequence')? draw.input: {theme: select, "font-size": 13};
 
         _.each(kinds, function(value, key) {
             if (key == type) {

--- a/js/draw.js
+++ b/js/draw.js
@@ -201,7 +201,7 @@ var draw = {
 
             draw.elements.css({'cursor':'pointer'}).each(function() {
                 this.parentNode.appendChild(this);
-            }).click(function().click(function() {draw.elClick(this.id);});
+            }).click(function() {draw.elClick(this.id);});
 
             //if ($(".theme").val() == "hand") $('.loadingImg').hide();
             //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}

--- a/js/draw.js
+++ b/js/draw.js
@@ -212,13 +212,13 @@ var draw = {
 
         //if ($(".theme").val() == "hand") draw.tChange();
 
-        var kinds = draw.kind[0];
-        draw.svg[draw.type] = $('svg').get(0);
-        var index = 0; for (key in kinds) {if(key == draw.type) nIndex = index; index++;}
+        var kinds = this.kind[0];
+        this.svg[this.type] = $('svg').get(0);
+        var index = 0; for (key in kinds) {if(key == this.type) nIndex = index; index++;}
 
         var n = ['0', '00', '99', '000', '999', '0000', '9999', '00000', '99999'].includes(id);
         var itemIndex = (n)? ((nIndex == 0)? index - 1 : nIndex - 1): ((nIndex + 1 == index)? 0: nIndex + 1);
-        draw.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
+        this.type = _.findKey(kinds, function(item) {return _.indexOf(Object.values(kinds), item) == itemIndex;});
 
 
         var jsonfile = '/assets/feed.json?t=' + $.now();
@@ -228,9 +228,9 @@ var draw = {
         $.getJSON(jsonfile).done(function(result){
 
             var obj = result.items[4].items[itemIndex];
-            draw.input = obj.input; draw.skema = draw.encode(obj.query);
-            if(itemIndex != index - 1) editor.setValue(draw.skema);
-            else {$(".theme").val("simple"); draw.tChange();}
+            this.input = obj.input; this.skema = this.encode(obj.query);
+            if(itemIndex != index - 1) editor.setValue(this.skema);
+            else {$(".theme").val("simple"); this.tChange();}
 
         });
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -202,8 +202,8 @@ var draw = {
                 this.parentNode.appendChild(this);
             }).css({'cursor':'pointer'}).click(function() {draw.elClick(this);});
 
-            if ($(".theme").val() == "hand") $('.loadingImg').hide();
-            else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
+            //if ($(".theme").val() == "hand") $('.loadingImg').hide();
+            //else {draw.svg[type] = $('svg').get(0); console.log(draw.svg[type]);}
         }
     },
 

--- a/js/draw.js
+++ b/js/draw.js
@@ -6,7 +6,6 @@ var editor = ace.edit("graphiql");
 editor.setOptions({fontSize: "10pt"});
 editor.setTheme("ace/theme/crimson_editor");
 editor.getSession().setMode("ace/mode/asciidoc");
-editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 100) );
 
 var draw = {
 
@@ -108,14 +107,15 @@ var draw = {
 
         } else {
 
+            editor.clearSelection(); editor.gotoLine(1, 1);
+            editor.getSession().on('change', _.debounce(function() {draw.diagram();}, 1000));
+
             //$('.chetabahana-skema').height($('.editor').height() + 200);
             //$('.editor-wrapper').height($('.editor').height() + 3);
             //$('.editor').height($('.diagram').height() - 94);
             $('.loadingImg').hide();
 
-            editor.clearSelection();
-            editor.gotoLine(1, 1);
-
+ 
             switch(draw.type) {
 
                 case 'flowchart':


### PR DESCRIPTION
### Summary
<!-- Please mention all relevant issue numbers. -->
Main Code: draw.js
```
                if (type == 'scenetree') {
                     $('#graphiql').show();
                     editor.destroy(); //editor.setValue("");
                     $("#editor").remove();
                }

```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

### Screenshots
![screencapture-chetabahana-github-io-2019-10-09-14_26_55](https://user-images.githubusercontent.com/36441664/66460579-67959000-eaa1-11e9-8957-887949a73a07.png)

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
